### PR TITLE
Added choice of cover type

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ The following configuration options are available. Note that they are all option
       "name": "My Device",
       "exclude": false,
       "hostname": "e.g. 192.168.1.200",
-      "password": "pa$$word"
+      "password": "pa$$word",
+      "coverType": "windowCovering"
     }
   ],
   "mdns": {
@@ -78,6 +79,7 @@ See below for descriptions of each configuration option.
 | `devices. exclude`              | Set this value to `true` to make this plugin ignore this device. |
 | `devices. hostname`             | The IP address or hostname of the device. Set this value if your device can't be discovered automatically. |
 | `devices. password`             | The password to use if authentication has been enabled for the device.
+| `devices. coverType`             | The type of device that is shown in Homekit, when the Shelly is in cover mode. Possible values: "awning, "door", "window", "windowCovering" |
 | `mdns`                          | Settings for the mDNS device discovery service. |
 | `mdns. enable`                  | Set this value to `false` to disable automatic device discovery using mDNS. |
 | `mdns. interface`               | The network interface to use when sending and receiving mDNS packets. You probably don't need to use this setting unless you know what you're doing. If not specified, all available network interfaces will be used. |

--- a/config.schema.json
+++ b/config.schema.json
@@ -84,6 +84,17 @@
               "title": "Password",
               "type": "string",
               "description": "The password to use if the Shelly device requires authentication."
+            },
+            "coverType": {
+              "title": "Cover type",
+              "type": "string",
+              "description": "If Shelly is in cover mode, choose how it should appear in HomeKit. This is only relevant if the device is in cover mode, otherwise it will be ignored. Default is Windows Covering.",
+              "oneOf": [
+                { "title": "Awning", "enum": ["awning"] },
+                { "title": "Door", "enum": ["door"] },
+                { "title": "Window", "enum": ["window"] },
+                { "title": "Window cover", "enum": ["windowCovering"] }
+              ]
             }
           }
         }
@@ -114,6 +125,12 @@
         },
         {
           "key": "devices[].password",
+          "condition": {
+            "functionBody": "return model.devices && !model.devices[arrayIndices[0]].exclude"
+          }
+        },
+        {
+          "key": "devices[].coverType",
           "condition": {
             "functionBody": "return model.devices && !model.devices[arrayIndices[0]].exclude"
           }

--- a/src/abilities/cover.ts
+++ b/src/abilities/cover.ts
@@ -4,6 +4,7 @@ import { Cover } from 'shellies-ng';
 import { Ability, ServiceClass } from './base';
 
 const names = {
+  'awning': 'Awning',
   'door': 'Door',
   'window': 'Window',
   'windowCovering': 'Window Covering',
@@ -13,7 +14,7 @@ export class CoverAbility extends Ability {
   /**
    * @param component - The cover component to control.
    */
-  constructor(readonly component: Cover, readonly type: 'door' | 'window' | 'windowCovering' = 'window') {
+  constructor(readonly component: Cover, readonly type: 'awning' | 'door' | 'window' | 'windowCovering' = 'windowCovering') {
     super(
       `${names[type]} ${component.id + 1}`,
       `${type}-${component.id}`,

--- a/src/config.ts
+++ b/src/config.ts
@@ -72,6 +72,10 @@ export interface DeviceOptions {
    * The password to use if the Shelly device requires authentication.
    */
   password?: string;
+   /**
+   * The homekit device type used, when the Shelly device is in cover mode.
+   */
+  coverType?: string;
 }
 
 const DEFAULT_DEVICE_OPTIONS: Readonly<DeviceOptions> = {

--- a/src/device-delegates/base.ts
+++ b/src/device-delegates/base.ts
@@ -163,12 +163,15 @@ export abstract class DeviceDelegate {
    * @param cover - The cover component to use.
    */
   protected createCover(cover: Cover): Accessory {
-    return this.createAccessory(
-      'cover',
-      'Window',
-      new CoverAbility(cover, 'window'),
-      new PowerMeterAbility(cover),
-    );
+    if (this.options.coverType === 'awning') {
+      return this.createAccessory('cover', 'Awning', new CoverAbility(cover, 'awning'), new PowerMeterAbility(cover));
+    } else if (this.options.coverType === 'door') {
+      return this.createAccessory('cover', 'Door', new CoverAbility(cover, 'door'), new PowerMeterAbility(cover));
+    } else if (this.options.coverType === 'window') {
+      return this.createAccessory('cover', 'Window', new CoverAbility(cover, 'window'), new PowerMeterAbility(cover));
+    } else {
+      return this.createAccessory('cover', 'Window Covering', new CoverAbility(cover, 'windowCovering'), new PowerMeterAbility(cover));
+    }
   }
 
   /**


### PR DESCRIPTION
In issue #28 people ask for adding a Shelly in cover mode as window covering and not as windows. As I had the same requirement, I decided to contribute and make some changes to the project.

- I added a parameter to the devices configuration where you can configure the type of device for Homekit
- The plugin defaults to windowCovering as most people would use a shelly to control a window covering and not a window.
- Added awning, as this is an official device category on Homekit

I tested this on Homebridge v1.5.0 on Nodejs v16.16.0 on Almalinux 9 and it worked for me as expected. It would be great if somebody else could do some more testing. 