### PR TITLE
Added support for Shelly Plus 1 Mini

### DIFF
--- a/src/device-delegates/shelly-plus-1-pm.ts
+++ b/src/device-delegates/shelly-plus-1-pm.ts
@@ -1,6 +1,7 @@
 import {
   ShellyPlus1Pm,
   ShellyPlus1PmUl,
+  ShellyPlus1PmMini,
 } from 'shellies-ng';
 
 import { DeviceDelegate } from './base';
@@ -20,4 +21,5 @@ DeviceDelegate.registerDelegate(
   ShellyPlus1PmDelegate,
   ShellyPlus1Pm,
   ShellyPlus1PmUl,
+  ShellyPlus1PmMini,
 );

--- a/src/device-delegates/shelly-plus-1.ts
+++ b/src/device-delegates/shelly-plus-1.ts
@@ -1,6 +1,7 @@
 import {
   ShellyPlus1,
   ShellyPlus1Ul,
+  ShellyPlus1Mini,
 } from 'shellies-ng';
 
 import { DeviceDelegate } from './base';
@@ -20,4 +21,5 @@ DeviceDelegate.registerDelegate(
   ShellyPlus1Delegate,
   ShellyPlus1,
   ShellyPlus1Ul,
+  ShellyPlus1Mini,
 );


### PR DESCRIPTION
Resolves #87 

**Dependency**
As the model IDs for the devices are defined in node-shellies-ng, the following Pull-Request must be merged first:
https://github.com/alexryd/node-shellies-ng/pull/7

Shelly has released "mini" versions for some of their new generation products. They basically have the same functions as the normal ones, but using different model IDs.

Change has been tested successfull in my local setup with the homebridge-shelly-ng plugin.
Best regards,
Swen