### PR TITLE
Add support for the Shelly Plus I4DC.

### DIFF
--- a/src/device-delegates/index.ts
+++ b/src/device-delegates/index.ts
@@ -4,6 +4,7 @@ export * from './shelly-plus-1';
 export * from './shelly-plus-1-pm';
 export * from './shelly-plus-2-pm';
 export * from './shelly-plus-i4';
+export * from './shelly-plus-i4dc';
 export * from './shelly-plus-plug-us';
 export * from './shelly-pro-1';
 export * from './shelly-pro-1-pm';

--- a/src/device-delegates/shelly-plus-i4dc.ts
+++ b/src/device-delegates/shelly-plus-i4dc.ts
@@ -1,0 +1,42 @@
+import { ShellyPlusI4DC } from 'shellies-ng';
+
+import { DeviceDelegate } from './base';
+import {
+  ReadonlySwitchAbility,
+  ServiceLabelAbility,
+  StatelessProgrammableSwitchAbility,
+} from '../abilities';
+
+/**
+ * Handles Shelly Plus I4DC devices.
+ */
+export class ShellyPlusI4DCDelegate extends DeviceDelegate {
+  protected setup() {
+    const d = this.device as ShellyPlusI4DC;
+
+    // determine each input type
+    const input0IsButton = d.input0.config?.type === 'button';
+    const input1IsButton = d.input1.config?.type === 'button';
+    const input2IsButton = d.input2.config?.type === 'button';
+    const input3IsButton = d.input3.config?.type === 'button';
+
+    // create an accessory for all button inputs
+    this.createAccessory(
+      'buttons',
+      null,
+      new StatelessProgrammableSwitchAbility(d.input0).setActive(input0IsButton),
+      new StatelessProgrammableSwitchAbility(d.input1).setActive(input1IsButton),
+      new StatelessProgrammableSwitchAbility(d.input2).setActive(input2IsButton),
+      new StatelessProgrammableSwitchAbility(d.input3).setActive(input3IsButton),
+      new ServiceLabelAbility(),
+    ).setActive(input0IsButton || input1IsButton || input2IsButton || input3IsButton);
+
+    // create accessories for all switch inputs
+    this.createAccessory('switch0', null, new ReadonlySwitchAbility(d.input0)).setActive(!input0IsButton);
+    this.createAccessory('switch1', null, new ReadonlySwitchAbility(d.input1)).setActive(!input1IsButton);
+    this.createAccessory('switch2', null, new ReadonlySwitchAbility(d.input2)).setActive(!input2IsButton);
+    this.createAccessory('switch3', null, new ReadonlySwitchAbility(d.input3)).setActive(!input3IsButton);
+  }
+}
+
+DeviceDelegate.registerDelegate(ShellyPlusI4DCDelegate, ShellyPlusI4DC);


### PR DESCRIPTION
The Shelly Plus I4DC is the DC version of the Shelly Plus I4, this device has a different model number than the main Shelly Plus I4.

This pull request has a dependency on [the pull request I made in node-shellies-ng](https://github.com/alexryd/node-shellies-ng/pull/13), the plugin will crash without this version of node-shellies-ng.